### PR TITLE
Support for multibyte for "chupa-text" command

### DIFF
--- a/lib/chupa-text/extractor.rb
+++ b/lib/chupa-text/extractor.rb
@@ -64,6 +64,7 @@ module ChupaText
         debug do
           "#{log_tag}[extract][target] <#{target.path}>:<#{target.mime_type}>"
         end
+        specify_encoding(target.body) if target.text?
         if target.text_plain?
           yield(target)
           next
@@ -94,6 +95,12 @@ module ChupaText
       else
         InputData.new(input)
       end
+    end
+
+    def specify_encoding(body)
+      return unless body.encoding == Encoding::ASCII_8BIT
+      body.force_encoding(Encoding.default_external)
+      body.force_encoding("UTF-8") unless body.valid_encoding?
     end
 
     def find_decomposer(data)

--- a/lib/chupa-text/formatters/json.rb
+++ b/lib/chupa-text/formatters/json.rb
@@ -32,7 +32,7 @@ module ChupaText
       def format_extracted(data)
         text = {}
         format_headers(data, text)
-        text["body"] = data.body
+        text["body"] = data.body.force_encoding(Encoding.default_external)
         @formatted["texts"] << text
       end
 

--- a/lib/chupa-text/formatters/json.rb
+++ b/lib/chupa-text/formatters/json.rb
@@ -32,7 +32,7 @@ module ChupaText
       def format_extracted(data)
         text = {}
         format_headers(data, text)
-        text["body"] = data.body.force_encoding(Encoding.default_external)
+        text["body"] = data.body
         @formatted["texts"] << text
       end
 

--- a/test/formatters/test-json.rb
+++ b/test/formatters/test-json.rb
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014  Masafumi Yokoyama <myokoym@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class TestFormattersJSON < Test::Unit::TestCase
+  include Helper
+
+  def setup
+    setup_io
+    @formatter = ChupaText::Formatters::JSON.new(@stdout)
+  end
+
+  def setup_io
+    @stdin  = StringIO.new
+    @stdout = StringIO.new
+  end
+
+  sub_test_case("from_text") do
+    def test_ascii
+      text = "Sapporo"
+      format(text)
+      assert(text)
+    end
+
+    def test_multibyte
+      text = "札幌"
+      format(text)
+      assert(text)
+    end
+
+    private
+    def format(text)
+      @stdin.write(text)
+      @stdin.rewind
+      @data = ChupaText::VirtualFileData.new(nil, @stdin)
+      @formatter.format_start(@data)
+      @formatter.format_extracted(@data)
+      @formatter.format_finish(@data)
+    end
+
+    def assert(text)
+      assert_equal({
+                     "mime-type" => "text/plain",
+                     "size"      => text.bytesize,
+                     "texts"     => [
+                       {
+                         "mime-type" => "text/plain",
+                         "size"      => text.bytesize,
+                         "body"      => text,
+                       },
+                     ],
+                   },
+                   JSON.parse(@stdout.string))
+    end
+  end
+end

--- a/test/formatters/test-json.rb
+++ b/test/formatters/test-json.rb
@@ -48,7 +48,9 @@ class TestFormattersJSON < Test::Unit::TestCase
       @stdin.rewind
       @data = ChupaText::VirtualFileData.new(nil, @stdin)
       @formatter.format_start(@data)
-      @formatter.format_extracted(@data)
+      ChupaText::Extractor.new.extract(@data) do |extracted|
+        @formatter.format_extracted(extracted)
+      end
       @formatter.format_finish(@data)
     end
 

--- a/test/test-extractor.rb
+++ b/test/test-extractor.rb
@@ -121,5 +121,15 @@ class TestExtractor < Test::Unit::TestCase
         assert_equal(["Hello", "Hello"], extract(data))
       end
     end
+
+    sub_test_case("encoding") do
+      def test_ascii8bit_to_default_external
+        data = ChupaText::Data.new
+        data.mime_type = "text/plain"
+        data.body = "Hello".force_encoding("ASCII-8BIT")
+        assert_equal(Encoding.default_external,
+                     extract(data).first.encoding)
+      end
+    end
   end
 end


### PR DESCRIPTION
Because the following error occurred:

``` zsh
% cat multibyte.txt
札幌
% chupa-text multibyte.txt
/.../lib/ruby/2.1.0/json/common.rb:285:in `encode': "\xE6" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
        from /.../lib/ruby/2.1.0/json/common.rb:285:in `generate'
        from /.../lib/ruby/2.1.0/json/common.rb:285:in `pretty_generate'
        from /.../lib/ruby/gems/2.1.0/gems/chupa-text-1.0.4/lib/chupa-text/formatters/json.rb:40:in `format_finish'
        from /.../lib/ruby/gems/2.1.0/gems/chupa-text-1.0.4/lib/chupa-text/command/chupa-text.rb:46:in `run'
        from /.../lib/ruby/gems/2.1.0/gems/chupa-text-1.0.4/lib/chupa-text/command/chupa-text.rb:25:in `run'
        from /.../lib/ruby/gems/2.1.0/gems/chupa-text-1.0.4/bin/chupa-text:21:in `<top (required)>'
        from /.../bin/chupa-text:23:in `load'
        from /.../bin/chupa-text:23:in `<main>'
```
