### PR TITLE
Add webrick to development_dependency

### DIFF
--- a/chupa-text.gemspec
+++ b/chupa-text.gemspec
@@ -60,4 +60,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("packnga")
   spec.add_development_dependency("rake")
   spec.add_development_dependency("test-unit")
+  spec.add_development_dependency("webrick")
 end


### PR DESCRIPTION
The following error occurs with `bundle exec rake`.

```
/home/runner/work/chupa-text/chupa-text/test/helper.rb:21:in `require': cannot load such file -- webrick (LoadError)
	from /home/runner/work/chupa-text/chupa-text/test/helper.rb:21:in `<top (required)>'
	from test/run-test.rb:35:in `require_relative'
	from test/run-test.rb:35:in `<main>'
rake aborted!
```