### PR TITLE
Fix file_uri build

### DIFF
--- a/lib/chupa-text/data.rb
+++ b/lib/chupa-text/data.rb
@@ -136,7 +136,7 @@ module ChupaText
     def uri=(uri)
       case uri
       when Pathname
-        file_uri = "file://#{escape_path(uri)}"
+        file_uri = convert_pathname_to_file_uri(uri)
         @uri = URI.parse(file_uri)
         self.path = uri
       when NilClass
@@ -237,7 +237,7 @@ module ChupaText
     end
 
     private
-    def escape_path(path)
+    def convert_pathname_to_file_uri(path)
       components = []
       escaped_path = nil
       target = path.expand_path
@@ -249,7 +249,7 @@ module ChupaText
           break
         end
       end
-      escaped_path
+      "file://#{escaped_path}"
     end
 
     def guess_mime_type

--- a/lib/chupa-text/data.rb
+++ b/lib/chupa-text/data.rb
@@ -136,14 +136,7 @@ module ChupaText
     def uri=(uri)
       case uri
       when Pathname
-        file_uri = ""
-        target = uri.expand_path
-        loop do
-          target, base = target.split
-          file_uri = "/#{CGI.escape(base.to_s)}#{file_uri}"
-          break if target.root?
-        end
-        file_uri = "file://#{file_uri}"
+        file_uri = "file://#{escape_uri(uri)}"
         @uri = URI.parse(file_uri)
         self.path = uri
       when NilClass
@@ -244,6 +237,21 @@ module ChupaText
     end
 
     private
+    def escape_uri(uri)
+      components = []
+      escaped_uri = nil
+      target = uri.expand_path
+      loop do
+        target, base = target.split
+        components.unshift(CGI.escape(base.to_s))
+        if target.root?
+          escaped_uri = target + components.join("/")
+          break
+        end
+      end
+      escaped_uri
+    end
+
     def guess_mime_type
       guess_mime_type_from_uri or
         guess_mime_type_from_body

--- a/lib/chupa-text/data.rb
+++ b/lib/chupa-text/data.rb
@@ -136,7 +136,7 @@ module ChupaText
     def uri=(uri)
       case uri
       when Pathname
-        file_uri = "file://#{escape_uri(uri)}"
+        file_uri = "file://#{escape_path(uri)}"
         @uri = URI.parse(file_uri)
         self.path = uri
       when NilClass
@@ -237,19 +237,19 @@ module ChupaText
     end
 
     private
-    def escape_uri(uri)
+    def escape_path(path)
       components = []
-      escaped_uri = nil
-      target = uri.expand_path
+      escaped_path = nil
+      target = path.expand_path
       loop do
         target, base = target.split
         components.unshift(CGI.escape(base.to_s))
         if target.root?
-          escaped_uri = target + components.join("/")
+          escaped_path = target + components.join("/")
           break
         end
       end
-      escaped_uri
+      escaped_path
     end
 
     def guess_mime_type


### PR DESCRIPTION
It did not work as expected on Windows.
expected: `file://D/a/chupa-text/chupa-text/test/fixture/command/chupa-text/hello.txt.gz`
actual:   `file:///a/chupa-text/chupa-text/test/fixture/command/chupa-text/hello.txt.gz`

This was fixed.