### PR TITLE
test: Change line breaks on windows

### DIFF
--- a/test/command/test-chupa-text.rb
+++ b/test/command/test-chupa-text.rb
@@ -56,7 +56,7 @@ class TestCommandChupaText < Test::Unit::TestCase
   sub_test_case("output") do
     sub_test_case("file") do
       def test_single
-        body = "Hello\n"
+        body = "Hello" + (Gem.win_platform? ? "\r\n" : "\n")
         fixture_name = "hello.txt"
         uri = fixture_uri(fixture_name).to_s
         path = fixture_path(fixture_name).to_s


### PR DESCRIPTION
Because the test fails due to a difference in line breaks code.