### PR TITLE
Add `.gitattributes` to specify line break code for `*.txt`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt text eol=lf


### PR DESCRIPTION
Because the test may fail due to line break code.