### PR TITLE
text-data: Fix uri and path override

### DIFF
--- a/lib/chupa-text/text-data.rb
+++ b/lib/chupa-text/text-data.rb
@@ -18,8 +18,7 @@ module ChupaText
   class TextData < Data
     def initialize(text, options={})
       super(options)
-      self.uri = uri.to_s.gsub(/\.[a-z\d]+\z/i, ".txt")
-      self.path = path.to_s.gsub(/\.[a-z\d]+\z/i, ".txt")
+      self.uri = Pathname(path.to_s.gsub(/\.[a-z\d]+\z/i, ".txt"))
       self.mime_type = "text/plain"
       self.body = text
       self.size = text.bytesize


### PR DESCRIPTION
Since `self.path` is also set in `Data#uri=`, there is no need to override it here.
Also, since converting a `URI` object to a string and replacing it does not produce the expected result, we convert it to a `Pathname` object by replacing `path`.