### PR TITLE
test: Improve file handle

### DIFF
--- a/test/test-default-logger.rb
+++ b/test/test-default-logger.rb
@@ -40,7 +40,9 @@ class TestDefaultLogger < Test::Unit::TestCase
       ENV["CHUPA_TEXT_LOG_OUTPUT"] = value
       logger = ChupaText::DefaultLogger.new
       device = logger.instance_variable_get(:@logdev)
-      device.dev
+      dev = device.dev
+      logger.close if dev.class == File
+      dev
     end
 
     def test_minus
@@ -52,8 +54,9 @@ class TestDefaultLogger < Test::Unit::TestCase
     end
 
     def test_string
-      file = Tempfile.new("chupa-text-default-logger-output")
-      assert_equal(file.path, output(file.path).path)
+      Tempfile.create("chupa-text-default-logger-output") do |file|
+        assert_equal(file.path, output(file.path).path)
+      end
     end
 
     def test_default
@@ -63,12 +66,14 @@ class TestDefaultLogger < Test::Unit::TestCase
 
   sub_test_case("rotation period") do
     def rotation_period(value)
-      file = Tempfile.new("chupa-text-default-logger-output")
-      ENV["CHUPA_TEXT_LOG_OUTPUT"] = file.path
-      ENV["CHUPA_TEXT_LOG_ROTATION_PERIOD"] = value
-      logger = ChupaText::DefaultLogger.new
-      device = logger.instance_variable_get(:@logdev)
-      device.instance_variable_get(:@shift_age)
+      Tempfile.create("chupa-text-default-logger-output") do |file|
+        ENV["CHUPA_TEXT_LOG_OUTPUT"] = file.path
+        ENV["CHUPA_TEXT_LOG_ROTATION_PERIOD"] = value
+        logger = ChupaText::DefaultLogger.new
+        logger.close
+        device = logger.instance_variable_get(:@logdev)
+        device.instance_variable_get(:@shift_age)
+      end
     end
 
     def test_daily
@@ -94,12 +99,14 @@ class TestDefaultLogger < Test::Unit::TestCase
 
   sub_test_case("N generation") do
     def n_generations(value)
-      file = Tempfile.new("chupa-text-default-logger-output")
-      ENV["CHUPA_TEXT_LOG_OUTPUT"] = file.path
-      ENV["CHUPA_TEXT_LOG_N_GENERATIONS"] = value
-      logger = ChupaText::DefaultLogger.new
-      device = logger.instance_variable_get(:@logdev)
-      device.instance_variable_get(:@shift_age)
+      Tempfile.create("chupa-text-default-logger-output") do |file|
+        ENV["CHUPA_TEXT_LOG_OUTPUT"] = file.path
+        ENV["CHUPA_TEXT_LOG_N_GENERATIONS"] = value
+        logger = ChupaText::DefaultLogger.new
+        logger.close
+        device = logger.instance_variable_get(:@logdev)
+        device.instance_variable_get(:@shift_age)
+      end
     end
 
     def test_integer
@@ -117,12 +124,14 @@ class TestDefaultLogger < Test::Unit::TestCase
 
   sub_test_case("max size") do
     def max_size(value)
-      file = Tempfile.new("chupa-text-default-logger-output")
-      ENV["CHUPA_TEXT_LOG_OUTPUT"] = file.path
-      ENV["CHUPA_TEXT_LOG_MAX_SIZE"] = value
-      logger = ChupaText::DefaultLogger.new
-      device = logger.instance_variable_get(:@logdev)
-      device.instance_variable_get(:@shift_size)
+      Tempfile.create("chupa-text-default-logger-output") do |file|
+        ENV["CHUPA_TEXT_LOG_OUTPUT"] = file.path
+        ENV["CHUPA_TEXT_LOG_MAX_SIZE"] = value
+        logger = ChupaText::DefaultLogger.new
+        logger.close
+        device = logger.instance_variable_get(:@logdev)
+        device.instance_variable_get(:@shift_size)
+      end
     end
 
     def test_unit

--- a/test/test-default-logger.rb
+++ b/test/test-default-logger.rb
@@ -40,9 +40,7 @@ class TestDefaultLogger < Test::Unit::TestCase
       ENV["CHUPA_TEXT_LOG_OUTPUT"] = value
       logger = ChupaText::DefaultLogger.new
       device = logger.instance_variable_get(:@logdev)
-      dev = device.dev
-      logger.close if dev.class == File
-      dev
+      device.dev
     end
 
     def test_minus
@@ -55,7 +53,9 @@ class TestDefaultLogger < Test::Unit::TestCase
 
     def test_string
       Tempfile.create("chupa-text-default-logger-output") do |file|
-        assert_equal(file.path, output(file.path).path)
+        device = output(file.path)
+        device.close
+        assert_equal(file.path, device.path)
       end
     end
 


### PR DESCRIPTION
```
D:/a/chupa-text/chupa-text/lib/chupa-text/default-logger.rb:82: warning: Exception in finalizer #<Tempfile::Remover:0x00000216c63f5c80 @pid=4548, @path="D:/a/_temp/chupa-text-default-logger-output20240517-4548-cdxyvd">
C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/3.3.0/tempfile.rb:319:in `unlink': Permission denied @ apply2files - D:/a/_temp/chupa-text-default-logger-output20240517-4548-cdxyvd (Errno::EACCES)
```

This will be a warning when removing temporary file.
Explicitly close the logger, as it is the same if the logger is left open.